### PR TITLE
Disable new jwt singing check

### DIFF
--- a/after-run.sh
+++ b/after-run.sh
@@ -7,6 +7,8 @@ JSON_EXE=/var/www/onlyoffice/documentserver/npm/json
 
 docker exec -it DocumentServer $JSON_EXE -f /etc/onlyoffice/documentserver/default.json -I -e 'this.services.CoAuthoring.expire.sessionidle="1h"'
 docker exec -it DocumentServer $JSON_EXE -f /etc/onlyoffice/documentserver/default.json -I -e 'this.services.CoAuthoring.autoAssembly.enable=true'
+docker exec -it DocumentServer $JSON_EXE -f /etc/onlyoffice/documentserver/default.json -I -e 'this.services.CoAuthoring.server.tokenRequiredParams=false'
+
 
 docker exec -it DocumentServer sed -i 's/WARN/ALL/g' /etc/onlyoffice/documentserver/log4js/production.json
 docker exec -it DocumentServer sed 's,autostart=false,autostart=true,' -i /etc/supervisor/conf.d/ds-example.conf


### PR DESCRIPTION
It was changed at:
https://github.com/ONLYOFFICE/server/pull/348/files

But CommunityServer v10.5 is incompatible with it
So disable it until we may upgrade CommunityServer on
testing portals